### PR TITLE
chore(flake): update inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "advisory-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1684873045,
-        "narHash": "sha256-MVXbXNXcqiaeJZbwVw6R16xqxJkpm+ipAIljz4/9QaM=",
+        "lastModified": 1685636567,
+        "narHash": "sha256-2/RpMMkX9q5hliqRi7ixsJXZhxbR+N3SAl7zSWSxB5I=",
         "owner": "rustsec",
         "repo": "advisory-db",
-        "rev": "e162556b9e8c1542c187290453cbd322e8905f0c",
+        "rev": "d32ef820108c8e87b956a57c3e8a3313bef78ccb",
         "type": "github"
       },
       "original": {
@@ -51,11 +51,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1685427675,
-        "narHash": "sha256-fWvqK8RhC6LABuUM7JL+loHhoRFcJx8rkAXGroVeKKw=",
+        "lastModified": 1685686868,
+        "narHash": "sha256-PFcFAdzA5yYP1m2eFuVlgtJeVnmkckUtCTTo+2wyc1s=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "9ea56d5de762971f6a7319711bae0532ca454dc9",
+        "rev": "3ba3e566c85c2a07e1152cfa758fa727052ae8b1",
         "type": "github"
       },
       "original": {
@@ -87,11 +87,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1685457039,
-        "narHash": "sha256-bEFtQm+YyLxQjKQAaBHJyPN1z2wbhBnr2g1NJWSYjwM=",
+        "lastModified": 1685662779,
+        "narHash": "sha256-cKDDciXGpMEjP1n6HlzKinN0H+oLmNpgeCTzYnsA2po=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "80717d11615b6f42d1ad2e18ead51193fc15de69",
+        "rev": "71fb97f0d875fd4de4994dfb849f2c75e17eb6c3",
         "type": "github"
       },
       "original": {
@@ -105,11 +105,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
         "type": "github"
       },
       "original": {
@@ -141,11 +141,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1685399834,
-        "narHash": "sha256-Lt7//5snriXSdJo5hlVcDkpERL1piiih0UXIz1RUcC4=",
+        "lastModified": 1685677062,
+        "narHash": "sha256-zoHF7+HNwNwne2XEomphbdc4Y8tdWT16EUxUTXpOKpQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "58c85835512b0db938600b6fe13cc3e3dc4b364e",
+        "rev": "95be94370d09f97f6af6a1df1eb9649b5260724e",
         "type": "github"
       },
       "original": {
@@ -200,11 +200,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1685378411,
-        "narHash": "sha256-Ufkqek5m8GzV3cz3Mw7bc0hO1d5hN0cO5BoTAK303K8=",
+        "lastModified": 1685637732,
+        "narHash": "sha256-MN+gEn1S8NAq3SW9sqxcI0+xBRNUJAPzv6z7hU7LDQE=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "bc8295255c5bcc293251d47590dcbfd320eaab87",
+        "rev": "0b4c09b1d2d3e6be0499f2683743716661821bf2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'advisory-db':
    'github:rustsec/advisory-db/e162556b9e8c1542c187290453cbd322e8905f0c' (2023-05-23)
  → 'github:rustsec/advisory-db/d32ef820108c8e87b956a57c3e8a3313bef78ccb' (2023-06-01)
• Updated input 'fenix':
    'github:nix-community/fenix/9ea56d5de762971f6a7319711bae0532ca454dc9' (2023-05-30)
  → 'github:nix-community/fenix/3ba3e566c85c2a07e1152cfa758fa727052ae8b1' (2023-06-02)
• Updated input 'fenix/rust-analyzer-src':
    'github:rust-lang/rust-analyzer/bc8295255c5bcc293251d47590dcbfd320eaab87' (2023-05-29)
  → 'github:rust-lang/rust-analyzer/0b4c09b1d2d3e6be0499f2683743716661821bf2' (2023-06-01)
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/80717d11615b6f42d1ad2e18ead51193fc15de69' (2023-05-30)
  → 'github:hercules-ci/flake-parts/71fb97f0d875fd4de4994dfb849f2c75e17eb6c3' (2023-06-01)
• Updated input 'flake-utils':
    'github:numtide/flake-utils/cfacdce06f30d2b68473a46042957675eebb3401' (2023-04-11)
  → 'github:numtide/flake-utils/a1720a10a6cfe8234c0e93907ffe81be440f4cef' (2023-05-31)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/58c85835512b0db938600b6fe13cc3e3dc4b364e' (2023-05-29)
  → 'github:NixOS/nixpkgs/95be94370d09f97f6af6a1df1eb9649b5260724e' (2023-06-02)
  ```