### PR TITLE
nix: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1715927173,
-        "narHash": "sha256-2S8hVck6nlyiBifzymDvePl5HWgqvVgxkBZCRax1qD8=",
+        "lastModified": 1716359173,
+        "narHash": "sha256-pYcjP6Gy7i6jPWrjiWAVV0BCQp+DdmGaI/k65lBb/kM=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "a2d19ef9305841f26c8ab908b1c09a84ca307e18",
+        "rev": "b6fc5035b28e36a98370d0eac44f4ef3fd323df6",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1715897893,
-        "narHash": "sha256-OrvqfRNUTKNg25z7+mCLV2PAnAjvdj/Z7HeS1g5OB7E=",
+        "lastModified": 1716451822,
+        "narHash": "sha256-0lT5RVelqN+dgXWWneXvV5ufSksW0r0TDQi8O6U2+o8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ea77cefecb0ab07e61d6bde3e24c7ae6820b96d5",
+        "rev": "3305b2b25e4ae4baee872346eae133cf6f611783",
         "type": "github"
       },
       "original": {
@@ -46,11 +46,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1715839492,
-        "narHash": "sha256-EyjtjocGLtB7tqyqwBfadP4y5BBtT5EkoG3kq/zym5U=",
+        "lastModified": 1716107283,
+        "narHash": "sha256-NJgrwLiLGHDrCia5AeIvZUHUY7xYGVryee0/9D3Ir1I=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "83ba42043166948db91fcfcfe30e0b7eac10b3d5",
+        "rev": "21ec8f523812b88418b2bfc64240c62b3dd967bd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'fenix':
    'github:nix-community/fenix/a2d19ef9305841f26c8ab908b1c09a84ca307e18?narHash=sha256-2S8hVck6nlyiBifzymDvePl5HWgqvVgxkBZCRax1qD8%3D' (2024-05-17)
  → 'github:nix-community/fenix/b6fc5035b28e36a98370d0eac44f4ef3fd323df6?narHash=sha256-pYcjP6Gy7i6jPWrjiWAVV0BCQp%2BDdmGaI/k65lBb/kM%3D' (2024-05-22)
• Updated input 'fenix/rust-analyzer-src':
    'github:rust-lang/rust-analyzer/83ba42043166948db91fcfcfe30e0b7eac10b3d5?narHash=sha256-EyjtjocGLtB7tqyqwBfadP4y5BBtT5EkoG3kq/zym5U%3D' (2024-05-16)
  → 'github:rust-lang/rust-analyzer/21ec8f523812b88418b2bfc64240c62b3dd967bd?narHash=sha256-NJgrwLiLGHDrCia5AeIvZUHUY7xYGVryee0/9D3Ir1I%3D' (2024-05-19)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/ea77cefecb0ab07e61d6bde3e24c7ae6820b96d5?narHash=sha256-OrvqfRNUTKNg25z7%2BmCLV2PAnAjvdj/Z7HeS1g5OB7E%3D' (2024-05-16)
  → 'github:NixOS/nixpkgs/3305b2b25e4ae4baee872346eae133cf6f611783?narHash=sha256-0lT5RVelqN%2BdgXWWneXvV5ufSksW0r0TDQi8O6U2%2Bo8%3D' (2024-05-23)
